### PR TITLE
Improve various texts

### DIFF
--- a/Dolphin scripts/Entrance Randomizer/CONFIGS.py
+++ b/Dolphin scripts/Entrance Randomizer/CONFIGS.py
@@ -15,7 +15,7 @@ STARTING_AREA: int | None = None
 """
 The ID of the Area to start in. `None` for random, `0xEE8F6900` for Crash Site.
 
-See `transition_infos.json` for all available IDs
+See `transition_infos.json` for all available IDs.
 
 default = None
 """
@@ -32,8 +32,8 @@ DISABLE_MAPS_IN_SHOP: bool = True
 """
 Whether you can buy maps in the Shaman Shop.
 
-When maps are disabled, and using original shop prices,
-the 4 lowest prices (0, 1, 2, 2) are also removed form the pool.
+When maps are disabled and using original shop prices,
+the 4 lowest prices (0, 1, 2, 2) are also removed from the pool.
 
 default = True
 """

--- a/Dolphin scripts/Entrance Randomizer/__main__.py
+++ b/Dolphin scripts/Entrance Randomizer/__main__.py
@@ -46,7 +46,7 @@ try:
 except KeyError:
     starting_area_name = hex(starting_area).upper() + " (not in randomization)"
 
-# Dump spoiler logs
+# Dump spoiler logs and graph
 dump_spoiler_logs(starting_area_name, transitions_map, seed_string)
 create_graphml(transitions_map, seed_string, starting_area)
 
@@ -66,8 +66,11 @@ async def main_loop():
     draw_text(f"Seed: {seed_string}")
     draw_text(patch_shaman_shop())
     draw_text(
-        f"Starting area: {hex(starting_area).upper()}"
-        + " (Random)" if CONFIGS.STARTING_AREA is None else f"{starting_area_name}",
+        "Starting area: " + (
+            f"{hex(starting_area).upper()} (Random)"
+            if CONFIGS.STARTING_AREA is None
+            else starting_area_name
+        ),
     )
     draw_text(
         f"Current area: {hex(state.current_area_new).upper()} "

--- a/Dolphin scripts/Entrance Randomizer/lib/utils.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/utils.py
@@ -52,9 +52,9 @@ def dump_spoiler_logs(
     spoiler_logs = f"Starting area: {starting_area_name}\n"
     for original, redirect in transitions_map.items():
         spoiler_logs += (
-            f"From: {TRANSITION_INFOS_DICT[original[0]].name}, "
-            + f"To: {TRANSITION_INFOS_DICT[original[1]].name}. "
-            + f"Redirecting to: {TRANSITION_INFOS_DICT[redirect[1]].name} "
+            f"{TRANSITION_INFOS_DICT[original[0]].name} "
+            + f"({TRANSITION_INFOS_DICT[original[1]].name} exit) "
+            + f"will redirect to: {TRANSITION_INFOS_DICT[redirect[1]].name} "
             + f"({TRANSITION_INFOS_DICT[redirect[0]].name} entrance)\n"
         )
 

--- a/Dolphin scripts/README.md
+++ b/Dolphin scripts/README.md
@@ -17,6 +17,27 @@
 6. In Dolphin, under "Scripts", click "Add new Scripts" and select `Scripts/Entrance Randomizer/__main__.py`.
 7. Enjoy and watch logs for errors 🙂
 
+### Features
+
+General:
+
+- Generation of Spoiler Log `.txt` file
+- Generation of Randomized Map `.graphml` file
+- Option to manually choose a seed, or to get a random seed
+
+Transitions:
+
+- Randomization of almost all basic transitions in the game
+- Option to manually choose a starting area, or to get a random starting area
+- Option to make all transitions 2-directional, or to allow 1-directional transitions
+- Option to skip both Jaguar fights entirely, or to keep them as normal
+
+Shaman Shop:
+
+- Randomization of Shaman Shop prices
+- Option to disable maps from the Shaman Shop, or to let them remain
+- Further options for Shaman Shop prices
+
 ### About the `.graphml` file
 
 In order to display the generated map take these steps:
@@ -29,7 +50,14 @@ In order to display the generated map take these steps:
 
 ### Known issues and limitations
 
-- To generate a new seed, simply reload the script.
+- To generate a new random seed, simply reload the script.
+- Saving and Loading is not supported by this randomizer. You can still do it, but the results will be unpredictable.
+  - This means "audio glitch", where sometimes the in-game music gets messed up and becomes very loud, currently has no solution while playing the randomizer.
+- Some seeds will result in impossible to complete configurations, because you might need some items to progress that you don't have yet.
+- When using `LINKED_TRANSITIONS = False` the generated `.graphml` map will become very hard to read, given the extreme amount of connections that will be drawn.
+- In rare occasions, a transition might send you to the game-intended level instead of the level decided by the randomizer (this is an issue with the script patching the destination).
+- In very rare occasions, a transition might not make you enter a level from the correct entrance, but make you enter from the default entrance instead
+  - The odds of this happening increase dramatically if at any point in the run Harry died or a save file was loaded.
 - Some linked transitions are not spawning at the right entrance and use the default entrance instead. Known cases:
   - Jungle Canyon from Punchau Shrine
   - Bittenbinder's Camp from Mysterious Temple
@@ -39,6 +67,6 @@ In order to display the generated map take these steps:
 
 1. Use this fork of Dolphin <https://github.com/Felk/dolphin/releases>.
 2. Turn on "Scripting" logs and set Verbosity to "Error" or any option below (not "Notice").
-3. Clone this repository
-4. Run `symlink-scripts.ps1 "<path to dolphin-scripting>"`
+3. Clone this repository.
+4. Run `symlink-scripts.ps1 "<path to dolphin-scripting>"`.
 5. In Dolphin, under "Scripts", click "Add new Scripts" and select `Scripts/Entrance Randomizer/__main__.py`.

--- a/Various technical notes/world_infos.json
+++ b/Various technical notes/world_infos.json
@@ -618,7 +618,7 @@
       "asset_id": null,
       "asset_crc32": "E0F1 09CC",
       "asset_name": "0-quentin",
-      "area_name": "Beta characters (IDEM)"
+      "area_name": "⚠ Beta characters (IDEM)"
     },
     {
       "id": 77,


### PR DESCRIPTION
- Add missing indication that `0-quentin` map spawns above the void
- Fixed disapplying non-random starting area
- Changed how transition mapping is written in spoiler logs
- Added rando features and more known issues to the readme
- Fixed a few typos

authored-by: @wossnameGitHub