### PR TITLE
Scan for previous area value across a range of addresses

### DIFF
--- a/Dolphin scripts/Entrance Randomizer/lib/constants.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/constants.py
@@ -31,7 +31,7 @@ print("Seed set to:", seed_string)
 @dataclass(frozen=True)
 class Addresses:
     version_string: str
-    prev_area: tuple[int, ...]
+    previous_area_blocks_ptr: int
     current_area: int
     area_load_state: int
     player_x: tuple[int, ...]
@@ -75,7 +75,7 @@ _addresses_map = {
     "GPH": {
         "D": Addresses(
             version_string="GC DE 0-00",
-            prev_area=(0x80747648,),
+            previous_area_blocks_ptr=TODO,
             current_area=0x80417F50,
             area_load_state=TODO,
             player_x=(),
@@ -86,7 +86,7 @@ _addresses_map = {
         ),
         "E": Addresses(
             version_string="GC US 0-00",
-            prev_area=(0x8072B648,),
+            previous_area_blocks_ptr=0x80425788,
             current_area=0x8041BEB4,
             area_load_state=0x8041BEC8,
             player_x=(0x8041BE4C, 0x338),
@@ -97,7 +97,7 @@ _addresses_map = {
         ),
         "F": Addresses(
             version_string="GC FR 0-00",
-            prev_area=(0x80747648,),
+            previous_area_blocks_ptr=TODO,
             current_area=0x80417F30,
             area_load_state=TODO,
             player_x=(),
@@ -108,7 +108,7 @@ _addresses_map = {
         ),
         "P": Addresses(
             version_string="GC EU 0-00",
-            prev_area=(0x80747648,),
+            previous_area_blocks_ptr=TODO,
             current_area=0x80417F10,
             area_load_state=TODO,
             player_x=(),
@@ -121,7 +121,7 @@ _addresses_map = {
     "RPF": {
         "E": Addresses(
             version_string="Wii US 0-00",
-            prev_area=(0x804542DC, 0x8),
+            previous_area_blocks_ptr=0x804542DC,
             current_area=0x80448D04,
             area_load_state=TODO,
             player_x=(),
@@ -132,7 +132,7 @@ _addresses_map = {
         ),
         "P": Addresses(
             version_string="Wii EU 0-00",
-            prev_area=(0x804546DC, 0x18),
+            previous_area_blocks_ptr=0x804546DC,
             current_area=0x80449104,
             area_load_state=TODO,
             player_x=(),

--- a/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
@@ -7,7 +7,7 @@ from typing import NamedTuple
 
 import CONFIGS
 from lib.constants import *  # noqa: F403
-from lib.utils import follow_pointer_path, state
+from lib.utils import PreviousArea, state
 
 
 class Transition(NamedTuple):
@@ -42,6 +42,7 @@ if CONFIGS.STARTING_AREA is not None:
 
 
 def highjack_transition_rando():
+    return None
     # Early return, faster check. Detect the start of a transition
     if state.current_area_old == state.current_area_new:
         return False
@@ -64,7 +65,7 @@ def highjack_transition_rando():
         f"Redirecting to: {hex(redirect.to)}",
         f"({hex(redirect.from_)} entrance)\n",
     )
-    memory.write_u32(follow_pointer_path(ADDRESSES.prev_area), redirect.from_)
+    PreviousArea.set(redirect.from_)
     memory.write_u32(ADDRESSES.current_area, redirect.to)
     return redirect
 


### PR DESCRIPTION
Idea for a potential hacky workaround to make "previous area id" a lot more stable across death and save loads