### PR TITLE
Remaining koala changes

### DIFF
--- a/Dolphin scripts/Entrance Randomizer/CONFIGS.py
+++ b/Dolphin scripts/Entrance Randomizer/CONFIGS.py
@@ -38,6 +38,14 @@ and you will fight Jaguar 2 before fighting Pusca.
 default = True
 """
 
+SKIP_WATER_LEVELS: bool = True
+"""
+If True, you will completely skip all 3 underwater levels.
+If False, these 3 levels are included in the randomization process normally.
+
+default = True
+"""
+
 IMMEDIATE_SPIRIT_FIGHTS: bool = True
 """
 If True, entering a Temple for which you haven't completed the spirit fight yet will immediately

--- a/Dolphin scripts/Entrance Randomizer/__main__.py
+++ b/Dolphin scripts/Entrance Randomizer/__main__.py
@@ -20,9 +20,12 @@ import CONFIGS
 from lib.constants import *  # noqa: F403
 from lib.constants import __version__
 from lib.entrance_rando import (
+    _transition_infos_dict_rando,
     CLOSED_DOOR_EXITS,
+    DISABLED_TRANSITIONS,
     NO_CONNECTION_FOUND_ERROR,
     SHOWN_DISABLED_TRANSITIONS,
+    bypassed_exits,
     highjack_transition_rando,
     set_transitions_map,
     starting_area,
@@ -51,7 +54,14 @@ except KeyError:
     starting_area_name = hex(starting_area).upper() + " (unknown level)"
 
 # Dump spoiler logs and graph
-dump_spoiler_logs(starting_area_name, transitions_map, seed_string)
+dump_spoiler_logs(
+    starting_area_name,
+    transitions_map,
+    seed_string,
+    _transition_infos_dict_rando,
+    bypassed_exits,
+    DISABLED_TRANSITIONS,
+)
 create_graphml(
     transitions_map,
     SHOWN_DISABLED_TRANSITIONS,

--- a/Dolphin scripts/Entrance Randomizer/__main__.py
+++ b/Dolphin scripts/Entrance Randomizer/__main__.py
@@ -122,8 +122,6 @@ async def main_loop():
         LevelCRC.VIRACOCHA_MONOLITHS,
     )
 
-    # TODO: Skip swim levels (3)
-
     highjack_transition_rando()
 
     prevent_item_softlock()

--- a/Dolphin scripts/Entrance Randomizer/__main__.py
+++ b/Dolphin scripts/Entrance Randomizer/__main__.py
@@ -24,9 +24,9 @@ from lib.entrance_rando import (
     CLOSED_DOOR_EXITS,
     DISABLED_TRANSITIONS,
     NO_CONNECTION_FOUND_ERROR,
-    SHOWN_DISABLED_TRANSITIONS,
     bypassed_exits,
     highjack_transition_rando,
+    manually_disabled_transitions,
     set_transitions_map,
     starting_area,
     transitions_map,
@@ -64,7 +64,7 @@ dump_spoiler_logs(
 )
 create_graphml(
     transitions_map,
-    SHOWN_DISABLED_TRANSITIONS,
+    manually_disabled_transitions,
     CLOSED_DOOR_EXITS,
     seed_string,
     starting_area,

--- a/Dolphin scripts/Entrance Randomizer/__main__.py
+++ b/Dolphin scripts/Entrance Randomizer/__main__.py
@@ -100,6 +100,13 @@ async def main_loop():
             return
         if highjack_transition(LevelCRC.GATES_OF_EL_DORADO, LevelCRC.JAGUAR, LevelCRC.PUSCA):
             return
+        # This does NOT influence how you start the level unfortunately,
+        # but at least it makes sure the Teleporters work right from the get-go.
+        if previous_area_id == LevelCRC.MAIN_MENU and state.current_area_new == starting_area:
+            memory.write_u32(
+                follow_pointer_path(ADDRESSES.prev_area),
+                TRANSITION_INFOS_DICT[starting_area].default_entrance,
+            )
 
     # Standardize the Altar of Ages exit to remove the Altar -> BBCamp transition
     highjack_transition(

--- a/Dolphin scripts/Entrance Randomizer/__main__.py
+++ b/Dolphin scripts/Entrance Randomizer/__main__.py
@@ -122,9 +122,6 @@ async def main_loop():
         LevelCRC.VIRACOCHA_MONOLITHS,
     )
 
-    # Standardize St. Claire's Excavation Camp
-    highjack_transition(None, LevelCRC.ST_CLAIRE_NIGHT, LevelCRC.ST_CLAIRE_DAY)
-
     # TODO: Skip swim levels (3)
 
     highjack_transition_rando()

--- a/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
@@ -64,13 +64,13 @@ _possible_starting_areas = [
     # Remove unwanted starting areas from the list of random possibilities
     if area not in {
         # These areas will instantly softlock you
-        LevelCRC.APU_ILLAPU_SHRINE,  # Softlock prevention just shoves you in the geyser anyway
+        LevelCRC.APU_ILLAPU_SHRINE,  # Softlock prevention would shove you in the geyser anyway
         # These areas will give too much progression
         LevelCRC.ST_CLAIRE_DAY,  # gives TNT
         LevelCRC.ST_CLAIRE_NIGHT,  # gives all items + access to El Dorado
         LevelCRC.JAGUAR,  # sends to final bosses
         LevelCRC.PUSCA,  # sends to final bosses
-        # Temples and spirits are effectively duplicates, so we remove half of them here.
+        # Temples and Spirits are mostly equivalent, so we remove half of them here.
         # Spawning in a temple forces you to do the fight anyway. For convenience let's spawn
         # directly in the fight (it's also funnier to start the rando as the animal spirit).
         *(
@@ -78,7 +78,7 @@ _possible_starting_areas = [
             if CONFIGS.IMMEDIATE_SPIRIT_FIGHTS
             else TEMPLES_WITH_FIGHT.values()
         ),
-        # Spawning in a Native Minigame is equivalent to spawning in Native Village
+        # Spawning in a Native Minigame is mostly equivalent to spawning in Native Village
         # as they are currently not randomized.
         LevelCRC.WHACK_A_TUCO,
         LevelCRC.TUCO_SHOOT,
@@ -93,8 +93,8 @@ _possible_starting_areas = [
 
 SHOWN_DISABLED_TRANSITIONS = (
     # Mouth of Inti has 2 connections with Altar of Huitaca, which causes problems,
-    # basically it's very easy to get softlocked by the spider web when entering Altar of Huitaca
-    # So for now just don't randomize it. That way runs don't just end out of nowhere
+    # basically it's very easy to get softlocked by the spider web when entering Altar of Huitaca.
+    # So for now just don't randomize it. That way runs don't just end out of nowhere.
     (LevelCRC.ALTAR_OF_HUITACA, LevelCRC.MOUTH_OF_INTI),
     (LevelCRC.MOUTH_OF_INTI, LevelCRC.ALTAR_OF_HUITACA),
 )
@@ -116,7 +116,7 @@ DISABLED_TRANSITIONS = (
     *SHOWN_DISABLED_TRANSITIONS,
     *bypassed_exits,
     # The 3 Spirit Fights are not randomized,
-    # because that will cause issues with the transformation cutscene trigger.
+    # because that causes issues with the transformation cutscene trigger.
     # Plus it wouldn't really improve anything, given that the Temples are randomized anyway.
     (LevelCRC.MONKEY_TEMPLE, LevelCRC.MONKEY_SPIRIT),
     (LevelCRC.MONKEY_SPIRIT, LevelCRC.MONKEY_TEMPLE),
@@ -125,8 +125,8 @@ DISABLED_TRANSITIONS = (
     (LevelCRC.PENGUIN_TEMPLE, LevelCRC.PENGUIN_SPIRIT),
     (LevelCRC.PENGUIN_SPIRIT, LevelCRC.PENGUIN_TEMPLE),
     # The 5 Native Games are currently chosen to not be randomized.
-    # If we at some point decide to randomize them anyway we'll have to do some rigorous testing
-    # Because it's very much possible this will cause some bugs
+    # If we at some point decide to randomize them anyway we'll have to do some rigorous testing,
+    # because it's very much possible this will cause some bugs.
     (LevelCRC.NATIVE_VILLAGE, LevelCRC.WHACK_A_TUCO),
     (LevelCRC.WHACK_A_TUCO, LevelCRC.NATIVE_VILLAGE),
     (LevelCRC.NATIVE_VILLAGE, LevelCRC.TUCO_SHOOT),

--- a/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
@@ -289,7 +289,7 @@ def remove_disabled_exits():
 def twin_outposts_underwater_prep():
     # create new area: Jungle Outpost (with 1 exit to Flooded Courtyard and 1 exit to Twin Outposts Underwater)
     _transition_infos_dict_rando[Outpost.JUNGLE] = Area(
-        Outpost.JUNGLE,
+        Outpost.JUNGLE.value,
         "Jungle Outpost",
         LevelCRC.FLOODED_COURTYARD,
         tuple(),
@@ -299,7 +299,7 @@ def twin_outposts_underwater_prep():
     add_exit(area, LevelCRC.TWIN_OUTPOSTS_UNDERWATER)
     # create new area: Burning Outpost (with 1 exit to Turtle Monument and 1 exit to Twin Outposts Underwater)
     _transition_infos_dict_rando[Outpost.BURNING] = Area(
-        Outpost.BURNING,
+        Outpost.BURNING.value,
         "Burning Outpost",
         LevelCRC.TURTLE_MONUMENT,
         tuple(),

--- a/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
@@ -106,10 +106,12 @@ SHOWN_DISABLED_TRANSITIONS = (
 bypassed_exits = [
     # The 2 CUTSCENE Levels are currently chosen to not be randomized.
     # As of right now both of these cutscenes are hijacked to be skipped entirely.
-    (LevelCRC.JAGUAR, LevelCRC.PLANE_CUTSCENE),
-    (LevelCRC.PLANE_CUTSCENE, LevelCRC.CRASH_SITE),
-    (LevelCRC.SPINJA_LAIR, LevelCRC.VIRACOCHA_MONOLITHS_CUTSCENE),
-    (LevelCRC.VIRACOCHA_MONOLITHS_CUTSCENE, LevelCRC.VIRACOCHA_MONOLITHS),
+    # NOTE: Commented out temporarily due to incompatibility
+    # with the current closed door logic
+    # (LevelCRC.JAGUAR, LevelCRC.PLANE_CUTSCENE),
+    # (LevelCRC.PLANE_CUTSCENE, LevelCRC.CRASH_SITE),
+    # (LevelCRC.SPINJA_LAIR, LevelCRC.VIRACOCHA_MONOLITHS_CUTSCENE),
+    # (LevelCRC.VIRACOCHA_MONOLITHS_CUTSCENE, LevelCRC.VIRACOCHA_MONOLITHS),
     # This specific one-time, one-way warp is not randomized.
     # Instead this transition is manually hijacked to send you to Mysterious Temple instead.
     (LevelCRC.ALTAR_OF_AGES, LevelCRC.BITTENBINDERS_CAMP),

--- a/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
@@ -206,9 +206,15 @@ def highjack_transition_rando():
         else:
             state.current_area_old = Outpost.BURNING
     elif state.current_area_new == LevelCRC.TWIN_OUTPOSTS:
-        if current_previous_area == 0X00D15464 or current_previous_area == 0XE1AE2BA4:
+        if (
+            current_previous_area == 0X00D15464
+            or current_previous_area == 0XE1AE2BA4
+        ):
             state.current_area_old = LevelCRC.TWIN_OUTPOSTS_UNDERWATER
-        if current_previous_area == 0X00D15464 or current_previous_area == LevelCRC.FLOODED_COURTYARD:
+        if (
+            current_previous_area == 0X00D15464
+            or current_previous_area == LevelCRC.FLOODED_COURTYARD
+        ):
             state.current_area_new = Outpost.JUNGLE
         else:
             state.current_area_new = Outpost.BURNING
@@ -333,7 +339,7 @@ def remove_disabled_exits():
 
 
 def twin_outposts_underwater_prep():
-    # create new area: Jungle Outpost (with 1 exit to Flooded Courtyard and 1 exit to Twin Outposts Underwater)
+    # create new area: Jungle Outpost
     _transition_infos_dict_rando[Outpost.JUNGLE] = Area(
         Outpost.JUNGLE.value,
         "Jungle Outpost",
@@ -343,7 +349,7 @@ def twin_outposts_underwater_prep():
     area = _transition_infos_dict_rando[Outpost.JUNGLE]
     add_exit(area, LevelCRC.FLOODED_COURTYARD)
     add_exit(area, LevelCRC.TWIN_OUTPOSTS_UNDERWATER)
-    # create new area: Burning Outpost (with 1 exit to Turtle Monument and 1 exit to Twin Outposts Underwater)
+    # create new area: Burning Outpost
     _transition_infos_dict_rando[Outpost.BURNING] = Area(
         Outpost.BURNING.value,
         "Burning Outpost",
@@ -353,7 +359,7 @@ def twin_outposts_underwater_prep():
     area = _transition_infos_dict_rando[Outpost.BURNING]
     add_exit(area, LevelCRC.TURTLE_MONUMENT)
     add_exit(area, LevelCRC.TWIN_OUTPOSTS_UNDERWATER)
-    # in area Twin outposts remove all 3 exits (is effectively the same as removing the level entirely)
+    # in area Twin outposts remove all 3 exits
     area = _transition_infos_dict_rando[LevelCRC.TWIN_OUTPOSTS]
     for i in range(3):
         delete_exit(

--- a/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/entrance_rando.py
@@ -85,10 +85,10 @@ _possible_starting_areas = [
 SHOWN_DISABLED_TRANSITIONS = (
     # Until we can set the "previous area id" in memory consistently,
     # Crash Site is a risk of progress reset
-    (LevelCRC.CRASH_SITE, LevelCRC.JUNGLE_CANYON),
-    (LevelCRC.CRASH_SITE, LevelCRC.PLANE_COCKPIT),
-    (LevelCRC.JUNGLE_CANYON, LevelCRC.CRASH_SITE),
-    (LevelCRC.PLANE_COCKPIT, LevelCRC.CRASH_SITE),
+    # (LevelCRC.CRASH_SITE, LevelCRC.JUNGLE_CANYON),
+    # (LevelCRC.CRASH_SITE, LevelCRC.PLANE_COCKPIT),
+    # (LevelCRC.JUNGLE_CANYON, LevelCRC.CRASH_SITE),
+    # (LevelCRC.PLANE_COCKPIT, LevelCRC.CRASH_SITE),
     # Mouth of Inti has 2 connections with Altar of Huitaca, which causes problems,
     # basically it's very easy to get softlocked by the spider web when entering Altar of Huitaca
     # So for now just don't randomize it. That way runs don't just end out of nowhere
@@ -106,12 +106,10 @@ SHOWN_DISABLED_TRANSITIONS = (
 bypassed_exits = [
     # The 2 CUTSCENE Levels are currently chosen to not be randomized.
     # As of right now both of these cutscenes are hijacked to be skipped entirely.
-    # NOTE: Commented out temporarily due to incompatibility
-    # with the current closed door logic
-    # (LevelCRC.JAGUAR, LevelCRC.PLANE_CUTSCENE),
-    # (LevelCRC.PLANE_CUTSCENE, LevelCRC.CRASH_SITE),
-    # (LevelCRC.SPINJA_LAIR, LevelCRC.VIRACOCHA_MONOLITHS_CUTSCENE),
-    # (LevelCRC.VIRACOCHA_MONOLITHS_CUTSCENE, LevelCRC.VIRACOCHA_MONOLITHS),
+    (LevelCRC.JAGUAR, LevelCRC.PLANE_CUTSCENE),
+    (LevelCRC.PLANE_CUTSCENE, LevelCRC.CRASH_SITE),
+    (LevelCRC.SPINJA_LAIR, LevelCRC.VIRACOCHA_MONOLITHS_CUTSCENE),
+    (LevelCRC.VIRACOCHA_MONOLITHS_CUTSCENE, LevelCRC.VIRACOCHA_MONOLITHS),
     # This specific one-time, one-way warp is not randomized.
     # Instead this transition is manually hijacked to send you to Mysterious Temple instead.
     (LevelCRC.ALTAR_OF_AGES, LevelCRC.BITTENBINDERS_CAMP),

--- a/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from lib.constants import *  # noqa: F403
 from lib.constants import __version__
+from lib.entrance_rando import TRANSITION_INFOS_DICT_RANDO
 from lib.types_ import SeedType
 
 
@@ -77,7 +78,7 @@ def create_vertices(
         # The same logic applies to the Spirit Fights:
         # these will never appear on the map, therefore we remove the (Harry) suffix.
         area_name = (
-            TRANSITION_INFOS_DICT
+            TRANSITION_INFOS_DICT_RANDO
             [area_id]
             .name
             .replace(" (Day)", "")

--- a/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
@@ -80,6 +80,14 @@ def create_vertices(
     if starting_area in spirit_fights:
         starting_area = TRANSITION_INFOS_DICT_RANDO[starting_area].exits[0].area_id
 
+    # This should be removed once Beta Volcano fully becomes part of the randomization process
+    if starting_area == LevelCRC.BETA_VOLCANO and starting_area not in area_ids_randomized:
+        holding_list = []
+        for area_id in area_ids_randomized:
+            holding_list.append(area_id)
+        holding_list.append(LevelCRC.BETA_VOLCANO)
+        area_ids_randomized = holding_list
+
     counter_x = 0
     counter_y = 0
     for area_id in area_ids_randomized:
@@ -141,6 +149,7 @@ def create_edges(
     transitions_map: Mapping[tuple[int, int], tuple[int, int]],
     shown_disabled_transitions: Iterable[tuple[int, int]],
     closed_door_exits: Container[tuple[int, int]],
+    starting_area: int,
 ):
     connections = list(transitions_map.items())
     connections_two_way: list[tuple[tuple[int, int], tuple[int, int]]] = []
@@ -162,6 +171,17 @@ def create_edges(
             else:
                 connections_one_way.append(pairing)
 
+    # This should be removed once Beta Volcano becomes a full part of the randomization process
+    if starting_area == LevelCRC.BETA_VOLCANO:
+        connections_one_way.append((
+            (LevelCRC.BETA_VOLCANO, LevelCRC.JUNGLE_CANYON),
+            (LevelCRC.BETA_VOLCANO, LevelCRC.JUNGLE_CANYON)
+        ))
+        connections_one_way.append((
+            (LevelCRC.BETA_VOLCANO, LevelCRC.PLANE_COCKPIT),
+            (LevelCRC.BETA_VOLCANO, LevelCRC.PLANE_COCKPIT)
+        ))
+
     output_text = ""
     counter = 1  # Can't start at 0 since that's the MAIN_MENU id
     for pairing in connections_two_way:
@@ -180,7 +200,8 @@ def create_edges(
             pairing[1][1],
             counter,
             Direction.ONEWAY,
-            None,
+            # Color should be removed once Volcano becomes a full part of the randomization process
+            UNRANDOMIZED_EDGE_COLOR if pairing[0][0] == LevelCRC.BETA_VOLCANO else None,
             LineType.DASHED,
         )
         counter += 1
@@ -210,7 +231,7 @@ def create_graphml(
         '<?xml version="1.0" encoding="UTF-8"?>'
         + '<graphml><graph id="Graph" uidGraph="1" uidEdge="1">\n'
         + create_vertices(all_transitions, starting_area)
-        + create_edges(all_transitions, shown_disabled_transitions, closed_door_exits)
+        + create_edges(all_transitions, shown_disabled_transitions, closed_door_exits, starting_area)
         + "</graph></graphml>"
     )
 

--- a/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from lib.constants import *  # noqa: F403
 from lib.constants import __version__
-from lib.entrance_rando import TRANSITION_INFOS_DICT_RANDO
+from lib.entrance_rando import _transition_infos_dict_rando, Outpost
 from lib.types_ import SeedType
 
 
@@ -78,7 +78,9 @@ def create_vertices(
         LevelCRC.PENGUIN_SPIRIT,
     )
     if starting_area in spirit_fights:
-        starting_area = TRANSITION_INFOS_DICT_RANDO[starting_area].exits[0].area_id
+        starting_area = TRANSITION_INFOS_DICT[starting_area].exits[0].area_id
+    elif starting_area == LevelCRC.TWIN_OUTPOSTS:
+        starting_area = Outpost.JUNGLE
 
     # This should be removed once Beta Volcano fully becomes part of the randomization process
     if starting_area == LevelCRC.BETA_VOLCANO and starting_area not in area_ids_randomized:
@@ -96,7 +98,7 @@ def create_vertices(
         # The same logic applies to the Spirit Fights:
         # these will never appear on the map, therefore we remove the (Harry) suffix.
         area_name = (
-            TRANSITION_INFOS_DICT_RANDO
+            _transition_infos_dict_rando
             [area_id]
             .name
             .replace(" (Day)", "")
@@ -133,8 +135,8 @@ def edge_component(
 ):
     direct_str = str(direct == Direction.ONEWAY).lower()
     return (
-        f'<edge source="{TRANSITION_INFOS_DICT[start].area_id}" '
-        + f'target="{TRANSITION_INFOS_DICT[end].area_id}" '
+        f'<edge source="{_transition_infos_dict_rando[start].area_id}" '
+        + f'target="{_transition_infos_dict_rando[end].area_id}" '
         + f'isDirect="{direct_str}" '
         + f'id="{counter}"'
         + create_own_style({

--- a/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
@@ -149,7 +149,7 @@ def edge_component(
 
 def create_edges(
     transitions_map: Mapping[tuple[int, int], tuple[int, int]],
-    shown_disabled_transitions: Iterable[tuple[int, int]],
+    manually_disabled_transitions: Iterable[tuple[int, int]],
     closed_door_exits: Container[tuple[int, int]],
     starting_area: int,
 ):
@@ -192,7 +192,7 @@ def create_edges(
             pairing[1][1],
             counter,
             Direction.TWOWAY,
-            UNRANDOMIZED_EDGE_COLOR if pairing[1] in shown_disabled_transitions else None,
+            UNRANDOMIZED_EDGE_COLOR if pairing[1] in manually_disabled_transitions else None,
             LineType.SOLID,
         )
         counter += 1
@@ -222,18 +222,18 @@ def create_edges(
 
 def create_graphml(
     transitions_map: Mapping[tuple[int, int], tuple[int, int]],
-    shown_disabled_transitions: Sequence[tuple[int, int]],
+    manually_disabled_transitions: Sequence[tuple[int, int]],
     closed_door_exits: Container[tuple[int, int]],
     seed_string: SeedType,
     starting_area: int,
 ):
-    all_transitions = dict(transitions_map) | {item: item for item in shown_disabled_transitions}
+    all_transitions = dict(transitions_map) | {item: item for item in manually_disabled_transitions}
 
     graphml_text = (
         '<?xml version="1.0" encoding="UTF-8"?>'
         + '<graphml><graph id="Graph" uidGraph="1" uidEdge="1">\n'
         + create_vertices(all_transitions, starting_area)
-        + create_edges(all_transitions, shown_disabled_transitions, closed_door_exits, starting_area)
+        + create_edges(all_transitions, manually_disabled_transitions, closed_door_exits, starting_area)
         + "</graph></graphml>"
     )
 

--- a/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
@@ -233,7 +233,9 @@ def create_graphml(
         '<?xml version="1.0" encoding="UTF-8"?>'
         + '<graphml><graph id="Graph" uidGraph="1" uidEdge="1">\n'
         + create_vertices(all_transitions, starting_area)
-        + create_edges(all_transitions, manually_disabled_transitions, closed_door_exits, starting_area)
+        + create_edges(
+            all_transitions, manually_disabled_transitions, closed_door_exits, starting_area
+        )
         + "</graph></graphml>"
     )
 

--- a/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/graph_creation.py
@@ -70,6 +70,16 @@ def create_vertices(
             ),
         ),
     )
+
+    # This technically isn't 100% accurate, but it makes the graph more readable
+    spirit_fights = (
+        LevelCRC.MONKEY_SPIRIT,
+        LevelCRC.SCORPION_SPIRIT,
+        LevelCRC.PENGUIN_SPIRIT,
+    )
+    if starting_area in spirit_fights:
+        starting_area = TRANSITION_INFOS_DICT_RANDO[starting_area].exits[0].area_id
+
     counter_x = 0
     counter_y = 0
     for area_id in area_ids_randomized:

--- a/Dolphin scripts/Entrance Randomizer/lib/utils.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/utils.py
@@ -81,6 +81,7 @@ def highjack_transition(
             f"Redirecting to: {hex(redirect)}",
         )
         memory.write_u32(ADDRESSES.current_area, redirect)
+        state.current_area_new = redirect
         return True
     return False
 

--- a/Dolphin scripts/Entrance Randomizer/lib/utils.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/utils.py
@@ -7,6 +7,7 @@ from typing import ClassVar
 from dolphin import gui  # pyright: ignore[reportMissingModuleSource]
 from lib.constants import *  # noqa: F403
 from lib.constants import __version__
+from lib.entrance_rando import _transition_infos_dict_rando
 from lib.types_ import SeedType
 
 DRAW_TEXT_STEP = 24
@@ -190,10 +191,10 @@ def dump_spoiler_logs(
 ):
     spoiler_logs = f"Starting area: {starting_area_name}\n"
     red_string_list = [
-        f"{TRANSITION_INFOS_DICT[original[0]].name} "
-        + f"({TRANSITION_INFOS_DICT[original[1]].name} exit) "
-        + f"will redirect to: {TRANSITION_INFOS_DICT[redirect[1]].name} "
-        + f"({TRANSITION_INFOS_DICT[redirect[0]].name} entrance)\n"
+        f"{_transition_infos_dict_rando[original[0]].name} "
+        + f"({_transition_infos_dict_rando[original[1]].name} exit) "
+        + f"will redirect to: {_transition_infos_dict_rando[redirect[1]].name} "
+        + f"({_transition_infos_dict_rando[redirect[0]].name} entrance)\n"
         for original, redirect in transitions_map.items()
     ]
     red_string_list.sort()

--- a/Dolphin scripts/Entrance Randomizer/lib/utils.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/utils.py
@@ -7,11 +7,6 @@ from typing import ClassVar
 from dolphin import gui  # pyright: ignore[reportMissingModuleSource]
 from lib.constants import *  # noqa: F403
 from lib.constants import __version__
-from lib.entrance_rando import (
-    _transition_infos_dict_rando,
-    bypassed_exits,
-    disabled_exits,
-)
 from lib.types_ import SeedType
 
 DRAW_TEXT_STEP = 24
@@ -192,6 +187,9 @@ def dump_spoiler_logs(
     starting_area_name: str,
     transitions_map: Mapping[tuple[int, int], tuple[int, int]],
     seed_string: SeedType,
+    _transition_infos_dict_rando: dict[int, Area],
+    bypassed_exits: list[tuple[int, int]],
+    DISABLED_TRANSITIONS: list[tuple[int, int]],
 ):
     spoiler_logs = f"Starting area: {starting_area_name}\n"
     red_string_list = [
@@ -209,7 +207,7 @@ def dump_spoiler_logs(
     non_random_string_list = [
         f"From: {TRANSITION_INFOS_DICT[pair[0]].name}, "
         + f"To: {TRANSITION_INFOS_DICT[pair[1]].name}.\n"
-        for pair in disabled_exits if pair not in bypassed_exits
+        for pair in DISABLED_TRANSITIONS if pair not in bypassed_exits
     ]
     non_random_string_list.sort()
     for string in non_random_string_list:

--- a/Dolphin scripts/Entrance Randomizer/lib/utils.py
+++ b/Dolphin scripts/Entrance Randomizer/lib/utils.py
@@ -7,7 +7,11 @@ from typing import ClassVar
 from dolphin import gui  # pyright: ignore[reportMissingModuleSource]
 from lib.constants import *  # noqa: F403
 from lib.constants import __version__
-from lib.entrance_rando import _transition_infos_dict_rando
+from lib.entrance_rando import (
+    _transition_infos_dict_rando,
+    bypassed_exits,
+    disabled_exits,
+)
 from lib.types_ import SeedType
 
 DRAW_TEXT_STEP = 24
@@ -201,17 +205,15 @@ def dump_spoiler_logs(
     for string in red_string_list:
         spoiler_logs += string
 
-    unrandomized_transitions = ALL_POSSIBLE_TRANSITIONS - transitions_map.keys()
-    if len(unrandomized_transitions) > 0:
-        spoiler_logs += "\nUnrandomized transitions:\n"
-        non_random_string_list = [
-            f"From: {TRANSITION_INFOS_DICT[transition[0]].name}, "
-            + f"To: {TRANSITION_INFOS_DICT[transition[1]].name}.\n"
-            for transition in unrandomized_transitions
-        ]
-        non_random_string_list.sort()
-        for string in non_random_string_list:
-            spoiler_logs += string
+    spoiler_logs += "\nUnrandomized transitions:\n"
+    non_random_string_list = [
+        f"From: {TRANSITION_INFOS_DICT[pair[0]].name}, "
+        + f"To: {TRANSITION_INFOS_DICT[pair[1]].name}.\n"
+        for pair in disabled_exits if pair not in bypassed_exits
+    ]
+    non_random_string_list.sort()
+    for string in non_random_string_list:
+        spoiler_logs += string
 
     # TODO (Avasam): Get actual user folder based whether Dolphin Emulator is in AppData/Roaming
     # and if the current installation is portable.

--- a/Dolphin scripts/README.md
+++ b/Dolphin scripts/README.md
@@ -17,11 +17,21 @@ General:
 
 Transitions:
 
-- Randomization of almost all basic transitions in the game
+- Randomization of almost all transitions in the game
 - Option to manually choose a starting area, or to get a random starting area
-- Option to make all transitions 2-directional, or to allow 1-directional transitions
+- Option to make all applicable transitions 2-directional, or to allow 1-directional transitions
 - Option to skip both Jaguar fights entirely, or to keep them as normal
+- Option to skip all 3 Underwater levels entirely, or to keep them as normal
 - Option to immediately spawn in the Spirit Fight when entering a temple, or to enter normally
+
+Softlock Prevention:
+
+- The algorithm will never generate a map that consists of multiple disconnected 'islands'
+- There will never be levels completely locked off from the rest due to closed doors
+- You will never run into a dead-end due to closed doors
+- Running into a closed door will give you back control over Harry, so you can at least go back where you came from
+- If you get locked in [Scorpion Temple] with no means of getting out, you will be granted Torch
+- If you get locked in [Apu Illapu Shrine] with no means of getting out, you will be kicked out of the level
 
 Shaman Shop:
 
@@ -44,6 +54,7 @@ Shaman Shop:
 5. Configurations are found in `Scripts/Entrance Randomizer/CONFIGS.py`.
 6. In Dolphin, under "Scripts", click "Add new Scripts" and select `Scripts/Entrance Randomizer/__main__.py`.
 7. Enjoy and watch logs for errors 🙂
+8. If you are using a random seed, to generate a different one simply reload the script.
 
 ### About the `.graphml` file
 
@@ -57,17 +68,18 @@ In order to display the generated map take these steps:
 
 ### Known issues and limitations
 
-- To generate a new random seed, simply reload the script.
+- Some seeds will result in impossible to complete configurations, because you might need some items to progress that you don't have yet.
 - Saving and Loading is not supported by this randomizer. You can still do it, but the results will be unpredictable.
   - This means "audio glitch", where sometimes the in-game music gets messed up and becomes very loud, currently has no solution while playing the randomizer.
-- Some seeds will result in impossible to complete configurations, because you might need some items to progress that you don't have yet.
+- If Harry dies at any point the randomizer becomes somewhat unstable. Some of these negative effects may be resolved by dying once more.
+- When using `LINKED_TRANSITIONS = False`, some of the newer features won't work properly. For instance, when using `SKIP_WATER_LEVELS = True` those water levels won't be skipped.
 - When using `LINKED_TRANSITIONS = False` the generated `.graphml` map will become very hard to read, given the extreme amount of connections that will be drawn.
+- When using `SKIP_JAGUAR = True`, after beating Pusca your maximum health will be reduced to 1.
+- Entering [Eyes of Doom] from a closed entrance may softlock the game, as the Softlock Prevention does not work properly for that specific level.
 - In rare occasions, a transition might send you to the game-intended level instead of the level decided by the randomizer (this is an issue with the script patching the destination).
-- In rare occasions, a transition might not make you enter a level from the correct entrance, but make you enter from the default entrance instead
+- In very rare occasions, a transition might not make you enter a level from the correct entrance, but make you enter from the default entrance instead
   - The odds of this happening increase dramatically if at any point in the run Harry died or a save file was loaded.
-- Some linked transitions are not spawning at the right entrance and use the default entrance instead. Known cases:
-  - Jungle Canyon from Punchau Shrine
-  - Bittenbinder's Camp from Mysterious Temple
+- In even rarer occasions, a transition might make you skip a level entirely, sending you from level_1 to level_3 without showing you level_2 at all.
 
 ### Developing
 

--- a/Various technical notes/transition_infos.json
+++ b/Various technical notes/transition_infos.json
@@ -1008,7 +1008,7 @@
     {
       "area_id": "0x1B8833D3",
       "area_name": "Mountain Sled Run",
-      "default_entrance": "0x8147EA91",
+      "default_entrance": "0x62548B77",
       "exits": [
         {
           "area_id": "0x8147EA91",


### PR DESCRIPTION
This MR consists of all changes I've made over the last month that have not yet been included in other MR's, plus some extra features.

Big features:
- Added Twin Outposts logic
- Added option to skip all 3 water levels
- Made a system where you can choose individual levels to ignore (like Crash Site)
- Split set_transitions_map() into smaller functions

Medium features:
- Accounted for Spirit fights in the graph
- Accounted for Beta Volcano in the graph
- Bugfix regarding St. Claire's Camp
- Bugfix regarding Altar of Ages
- Bugfix regarding Teleports
- Changed the wording on a whole bunch of comments
- Updated Spoiler Log
- Updated README.md
- Added Mountain Sled Run meme

I have purposefully not made a changelog entry, as I do not know in what order these changes will make it to Avasam/main. Either myself or Avasam will make a changelog entry by the time these changes make it to Avasam/main.